### PR TITLE
docs: expand README with usage examples and installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The initial design of this module is to find a certificate meeting a set of basi
 
 ## Python Implementation
 
-This code is designed to return a certificate that can be utalized when connecting with the python requests library.
+This code is designed to return a certificate that can be utilized when connecting with the python requests library.
 
 ```python
 from py_cert_store import get_win_cert

--- a/README.md
+++ b/README.md
@@ -9,25 +9,57 @@ The Python Certificate Store (Py_Cert_Store) is a module designed with the inten
 
 The initial design of this module is to find a certificate meeting a set of basic criteria (Not expired, contains an extension, and is exportable).
 
-# Note:
+## Python Implementation
 
-This project is a Work in Progress and changes will be made
-
-## Python Implementation (WIP)
-
-This code is designed to return information about a discovered certificate; this information can be used to write a new SSL connection.
+This code is designed to return a certificate that can be utalized when connecting with the python requests library.
 
 ```python
-import py_cert_store
-from cryptography import x509 # This feature is not working currently # Optional, but highly recomended
+from py_cert_store import get_win_cert
+from requests import Session
+from requests_pkcs12 import Pkcs12Adapter
 
-key_usage_oid = x509.OID_KEY_USAGE
+certificate = get_win_cert()
 
-certificate = py_cert_store.find_windows_cert_by_extension(
-    store="MY",
-    extension_oid=key_usage_oid.dotted_string,
-    extension_value="Digital Signature"
-)
+with Session() as s:
+    s.mount('https://example.com', Pkcs12Adapter(pkcs12_data=certificate))
+    r = s.get('https://example.com/test')
 ```
 
-WIP: How to use the certificate found by the module with a new ssl context
+For further selection of a certificate from the windows certificate store 
+
+```python
+from py_cert_store import find_windows_cert_by_extension
+from cryptography import x509
+
+valid_certificates = find_windows_cert_by_extension(
+    store="My", user:str="CurrentUser",
+    extension_oid=x509.OID_KEY_USAGE.dotted_string,
+    extension_value="Digital Signature"
+)
+
+certificate_with_metadata = valid_certificates[0]
+
+print(f"Using Certificate: {certificate_with_metadata['FriendlyName']}")
+print(f"{certificate_with_metadata['Name']}")
+print(f"Validity: {certificate_with_metadata['EffectiveDateString']} - {certificate_with_metadata['ExpirationDateString']}")
+
+certificate = certificate_with_metadata["cert"]
+
+...
+```
+<!-- ```python
+``` -->
+
+## Installing
+
+This library is available as [PyPI package](https://pypi.org/project/py-cert-store):
+
+```
+pip install py_cert_store
+```
+
+Alternatively, you can retrieve the latest development version via Git: (Note: Rust must be installed to run the development branch)
+
+```
+git clone https://github.com/unwarymold9171/Py_Cert_Store.git
+```


### PR DESCRIPTION
Add detailed Python usage examples demonstrating how to retrieve and use certificates from the Windows certificate store with requests and requests_pkcs12. Clarify the purpose of the module and show how to select certificates by extension. Include installation instructions for both PyPI and GitHub sources. These changes improve onboarding and clarify module usage for developers.